### PR TITLE
板位写具体高度，反包票标注「N天M板」

### DIFF
--- a/duanxian/market_facts.py
+++ b/duanxian/market_facts.py
@@ -40,6 +40,33 @@ def is_limit_up(ret: float, code: str, name: str = "", tol: float = 0.3) -> bool
     return ret >= limit_pct(code, name) - tol
 
 
+def board_label(boards: int, zt_stat: Optional[str] = None) -> str:
+    """连板标注：普通连板写「N板」；断板后反包的（东财涨停统计 N/M，N > M）写「N天M板」。
+
+    东财「连板数」对反包票只给 1（今天重新涨停），单看它会写成「1板」，
+    把「3天2板」这种回流反包结构完全抹掉 —— 所以优先用涨停统计。
+    """
+    if zt_stat:
+        try:
+            d, b = str(zt_stat).split("/")
+            d, b = int(d), int(b)
+            if b > 0 and d > b:
+                return f"{d}天{b}板"
+            if b > 0:
+                return f"{b}板"
+        except (ValueError, TypeError):
+            pass
+    return f"{int(boards or 1)}板"
+
+
+def stat_boards(zt_stat: Optional[str]) -> int:
+    """涨停统计「N/M」里的 M（有效高度）。取不到给 0。"""
+    try:
+        return int(str(zt_stat).split("/")[1])
+    except (ValueError, TypeError, IndexError, AttributeError):
+        return 0
+
+
 # ---------------------------------------------------------------- 三池明细
 def _df_rows(df, mapping: dict[str, str]) -> list[dict]:
     """DataFrame → list[dict]，按 mapping 取列（缺列给 None，不让整表报废）。"""
@@ -65,7 +92,7 @@ _ZT_MAP = {
     "code": "代码", "name": "名称", "ret": "涨跌幅", "amount": "成交额",
     "turnover": "换手率", "seal_fund": "封板资金", "first_seal": "首次封板时间",
     "last_seal": "最后封板时间", "broken_times": "炸板次数", "boards": "连板数",
-    "sector": "所属行业",
+    "zt_stat": "涨停统计", "sector": "所属行业",
 }
 _ZB_MAP = {
     "code": "代码", "name": "名称", "ret": "涨跌幅", "turnover": "换手率",
@@ -323,7 +350,8 @@ def feedback_matrix(date: str, prev: Optional[str] = None) -> dict:
         got = [r for r in srows if r.get("ret") is not None]
         if got:
             def tier(b: int) -> str:
-                return "首板" if b <= 1 else ("2板" if b == 2 else "3板及以上")
+                # 板位写具体高度（3板/4板/…/9板），不再笼统归成「3板及以上」
+                return "首板" if b <= 1 else f"{b}板"
 
             matrix: dict[str, dict] = {}
             details: list[dict] = []
@@ -383,9 +411,7 @@ def feedback_matrix(date: str, prev: Optional[str] = None) -> dict:
             return "昨日炸板"
         if b == 1:
             return "首板"
-        if b == 2:
-            return "2板"
-        return "3板及以上"
+        return f"{b}板"   # 同定稿路径：写具体高度，不归并「3板及以上」
 
     matrix: dict[str, dict] = {}
     details: list[dict] = []

--- a/duanxian/theme_tree.py
+++ b/duanxian/theme_tree.py
@@ -151,6 +151,7 @@ def build(date: str, prev: Optional[str] = None, top: int = 10) -> dict:
             continue                 # 问财有、东财涨停池没有 → 不计入覆盖
         matched += 1
         b = int(r.get("boards") or 1)
+        stat = str(r.get("zt_stat") or "") or None
         t = str(r.get("first_seal") or "").strip()
         for tag in _tags(reason):
             grp = g(tag)
@@ -164,6 +165,9 @@ def build(date: str, prev: Optional[str] = None, top: int = 10) -> dict:
                 grp["seal_times"].append(t)
             grp["members"].append({
                 "code": r["code"], "name": r["name"], "boards": b,
+                "zt_stat": stat, "label": mf.board_label(b, stat),
+                # 反包票（3天2板）东财连板数只给 1，排序按有效高度，别沉到榜尾
+                "_h": max(b, mf.stat_boards(stat)),
                 "first_seal": t or None, "broken_times": int(r.get("broken_times") or 0),
             })
 
@@ -204,7 +208,9 @@ def build(date: str, prev: Optional[str] = None, top: int = 10) -> dict:
                                     if grp["prev_members"] else None)
         # 状态标签只由客观读数推出，不含前瞻判断
         grp["state"] = _state_of(grp, has_prev_reasons)
-        grp["members"] = sorted(grp["members"], key=lambda x: -x["boards"])[:8]
+        grp["members"] = sorted(grp["members"], key=lambda x: -x["_h"])[:8]
+        for m in grp["members"]:
+            m.pop("_h", None)
         out.append(grp)
     out.sort(key=lambda x: (-x["limit_up"], -x["highest"]))
 
@@ -272,7 +278,7 @@ def render(tree: dict) -> str:
             seg += f"；昨日该题材{t['prev_members']}只涨停，今日仍涨停{t['prev_still_up']}只"
             if cr is not None:
                 seg += f"（延续率{cr:.0%}）"
-        names = "、".join(f"{m['name']}{m['boards']}板" for m in t["members"][:3])
+        names = "、".join(f"{m['name']}{m.get('label') or str(m['boards']) + '板'}" for m in t["members"][:3])
         if names:
             seg += f"；代表：{names}"
         lines.append(seg)

--- a/frontend/src/components/MarketFactsPanel.tsx
+++ b/frontend/src/components/MarketFactsPanel.tsx
@@ -65,7 +65,11 @@ export function Section({
 /** 昨日强势股反馈矩阵：按昨日板位分组，看今天各落到什么结果 */
 export function Matrix({ fm }: { fm?: FeedbackMatrix }) {
   const matrix = safeRecord<FeedbackCell>(fm?.matrix);
-  const tiers = ["首板", "2板", "3板及以上", "昨日炸板"].filter((t) => matrix[t]);
+  // 板位写具体高度（首板/2板/3板/…/9板），档位动态从 matrix 键生成：
+  // 首板固定最前、「昨日炸板」固定最后，中间按数字升序
+  const tierOrder = (t: string) =>
+    t === "首板" ? 1 : t === "昨日炸板" ? Number.MAX_SAFE_INTEGER : (parseInt(t, 10) || Number.MAX_SAFE_INTEGER - 1);
+  const tiers = Object.keys(matrix).sort((a, b) => tierOrder(a) - tierOrder(b));
   const cols = ["晋级涨停", "收红", "小跌", "跌超5%", "跌停"] as const;
   return (
     <Section
@@ -360,10 +364,10 @@ export function ThemeTreeView({ t }: { t?: ThemeTree }) {
                       {n.continuation_rate != null && `（延续 ${rate(n.continuation_rate)}）`}
                     </span>
                   )}
-                  {safeArray<{ name: string; boards: number }>(n.members).length > 0 && (
+                  {safeArray<{ name: string; boards: number; label?: string }>(n.members).length > 0 && (
                     <span className="truncate opacity-70">
-                      {safeArray<{ name: string; boards: number }>(n.members).slice(0, 4)
-                        .map((m) => `${m.name}${m.boards}板`).join("、")}
+                      {safeArray<{ name: string; boards: number; label?: string }>(n.members).slice(0, 4)
+                        .map((m) => `${m.name}${m.label ?? `${m.boards}板`}`).join("、")}
                     </span>
                   )}
                 </div>

--- a/frontend/src/lib/agent.ts
+++ b/frontend/src/lib/agent.ts
@@ -268,7 +268,7 @@ export interface ThemeNode {
   /** 昨日该题材涨停股今天还剩多少仍涨停 */
   prev_members: number; prev_still_up: number; prev_broken_or_down: number;
   continuation_rate: number | null;
-  members: { code: string; name: string; boards: number; first_seal: string | null; broken_times: number }[];
+  members: { code: string; name: string; boards: number; label?: string; zt_stat?: string | null; first_seal: string | null; broken_times: number }[];
 }
 export interface ThemeTree extends FactBase {
   date?: string; prev_date?: string; tag_count?: number;

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -3222,10 +3222,40 @@ class TestPastSessionsStayViewable:
 
         r = mf.feedback_matrix("2026-07-29")
         assert r["available"] is True and r["source"] == "settled"
-        assert set(r["matrix"]) == {"首板", "2板", "3板及以上"}
-        assert r["matrix"]["3板及以上"]["晋级涨停"] == 1
+        assert set(r["matrix"]) == {"首板", "2板", "3板"}
+        assert r["matrix"]["3板"]["晋级涨停"] == 1
         assert r["matrix"]["2板"]["跌超5%"] == 1
         assert "炸板" in r["note"], "缺的那一档要说出来"
+
+
+@pytest.mark.unit
+class TestBoardLabel:
+    """连板标注：反包票要写「N天M板」，不能被东财连板数=1 抹成「1板」。
+
+    欢瑞世纪 2026-07-31 就是实例：东财「连板数」给 1（断板后重新涨停），
+    「涨停统计」给 "3/2"。只写「1板」会把题材回流反包的结构完全隐藏。
+    """
+
+    def test_fanbao_uses_zt_stat(self):
+        from duanxian.market_facts import board_label
+
+        assert board_label(1, "3/2") == "3天2板"
+        assert board_label(1, "4/2") == "4天2板"
+
+    def test_normal_consec_uses_boards(self):
+        from duanxian.market_facts import board_label
+
+        assert board_label(3, "3/3") == "3板"
+        assert board_label(9, "9/9") == "9板"
+        assert board_label(2, None) == "2板"
+        assert board_label(1, "") == "1板"
+
+    def test_garbage_stat_falls_back(self):
+        from duanxian.market_facts import board_label, stat_boards
+
+        assert board_label(2, "乱码") == "2板"
+        assert stat_boards("3/2") == 2
+        assert stat_boards(None) == 0
 
     def test_docs_dont_claim_intraday_cannot_compute(self):
         """README 不许再说「盘中算不了、等收盘再跑」——那是改之前的行为。


### PR DESCRIPTION
## 问题

两处短线复盘口径偏粗，都会把关键结构信息抹掉：

**1. 昨日强势股反馈矩阵把 3 板以上归并成「3板及以上」**
9 板高标和 3 板中位股落在同一档，梯队断不断层、高标承接如何，从矩阵里看不出来。

**2. 题材事件树成员只按「连板数」标注，反包票被写成「1板」**
东财涨停池的「连板数」对断板反包的票只给 1（今天重新涨停），但源数据里本来就有「涨停统计」（形如 `3/2`）。实例：2026-07-31 的欢瑞世纪，`连板数=1` + `涨停统计=3/2`，旧逻辑标成「欢瑞世纪1板」——题材回流反包的结构完全隐藏。且成员按连板数排序，反包票沉到榜尾，题材卡片上看着像只有 1 板 2 板的票。

## 改动

- `market_facts.py`：反馈矩阵定稿/实时两条路径的分档改为具体高度（首板/2板/3板/…/9板）；`_ZT_MAP` 补 `zt_stat`（涨停统计）；新增 `board_label()`（反包写「N天M板」，普通连板写「N板」）与 `stat_boards()`。
- `theme_tree.py`：成员带 `label`/`zt_stat`，排序按有效高度（涨停统计 M 与连板数取大），AI prompt 的题材树文本用同一标注。
- 前端 `MarketFactsPanel.tsx`：矩阵档位从 matrix 键动态生成、按板数升序；题材树成员优先显示 `label`。`agent.ts` 类型同步。
- 测试：更新反馈矩阵分档断言；新增 `TestBoardLabel` 三组用例（反包 / 普通连板 / 脏数据回退）。

## 效果（2026-07-31 实盘数据验证）

- 反馈矩阵档位：`首板 / 2板 / 3板 / 4板 / 8板`（爱丽家居昨日 8 板今天晋级 9 板，单独一档）
- AI应用：欢瑞世纪**3天2板**（原显示 1板，且排到成员第一位）
- 算力租赁：美利云**10天5板**；存储芯片：爱丽家居**20天10板**

本地 `pytest` 342 passed（1 个 `TestCliBackendPreflight` 失败在未改动的 main 上同样出现，是依赖本机 CLI 安装情况的环境用例，与本 PR 无关）。

> ⚠️ 兼容说明：已落盘的 `market_facts` 缓存里归一化行没有 `zt_stat`，会回退到「N板」标注（不报错）；重新取数或给缓存行从 `raw` 补 `涨停统计` 后即按新标注显示。