### PR TITLE
fix(settings): 下拉框回显自定义模型 / Fix model dropdown for custom models

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -20,7 +20,9 @@ export function Settings() {
   const [cliId, setCliId] = useState(existing && existingIsCli ? existing.model : "");
   // API：选中的模型 id + 可编辑的 baseURL / model / key
   const firstApi = apiModels[0];
-  const [apiId, setApiId] = useState(existing && !existingIsCli ? existing.model : firstApi.id);
+  // ponytail: custom model not in preset list → select won't match any option → fallback to first item
+  const matchedApi = existing && !existingIsCli ? apiModels.find((m) => m.id === existing.model) : null;
+  const [apiId, setApiId] = useState(matchedApi ? matchedApi.id : "custom");
   const [baseURL, setBaseURL] = useState(existing && !existingIsCli ? existing.baseURL : (PROVIDER_BASE[firstApi.provider] || ""));
   const [modelName, setModelName] = useState(existing && !existingIsCli ? existing.model : firstApi.id);
   const [apiKey, setApiKey] = useState(existing && !existingIsCli ? existing.apiKey : "");


### PR DESCRIPTION
## Problem
Custom model id not in preset list → <select> value matches no <option> → browser falls back to first item.

## Fix
Same root cause as [Vibe-Research PR#30](https://github.com/simonlin1212/Vibe-Research/pull/30).
Check if stored model is in preset list; if not, default to "custom".

1 file, +3 -1.