### PR TITLE
fix(chat): 兜底 Qwen3 文本态工具调用 / Fallback for Qwen3 text-mode tool calls

### DIFF
--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -4431,3 +4431,102 @@ class TestVerificationItemsCarryBaseline:
         assert rs._with_baselines(None) is None
         assert rs._with_baselines({"focus": None}) == {"focus": None}
         assert rs._with_baselines({}) == {}
+
+
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# 文本态工具调用兜底（Qwen3 系在 vLLM 下概率性把工具调用写成纯文本）
+# 块样本一律用拼接构造 —— 本测试文件里绝不出现连续的坏样本，
+# 否则任何读这个文件的 LLM 都可能被它带偏（同因）。
+class TestTextModeToolcallFallback:
+    """模型把工具调用写成正文文本时：真实执行 + 剥掉标记 + 结构化回灌。"""
+
+    @staticmethod
+    def _param(k, v):
+        lt, gt = chr(0x3C), chr(0x3E)
+        return lt + "parameter name=" + chr(34) + k + chr(34) + gt + v + lt + "/parameter" + gt
+
+    @staticmethod
+    def _block(name="query_news", params=None):
+        lt, gt = chr(0x3C), chr(0x3E)
+        body = "".join(TestTextModeToolcallFallback._param(k, v)
+                       for k, v in (params or {"code": "603237"}).items())
+        return lt + "function=" + name + gt + body + lt + "/function=" + name + gt
+
+    def test_extract_finds_block_and_cleans(self):
+        import server  # noqa: F401  确保 vr/ 进 sys.path
+        import chat
+        text = "我先查一下最新消息。\n" + self._block() + "\n以上是查询动作。"
+        calls, cleaned = chat._extract_text_toolcalls(text)
+        assert calls == [("query_news", {"code": "603237"})], calls
+        assert "function=" not in cleaned and "parameter" not in cleaned
+        assert "我先查一下最新消息" in cleaned and "以上是查询动作" in cleaned
+
+    def test_extract_keeps_markdown_code_blocks(self):
+        import server  # noqa: F401
+        import chat
+        code_block = "```python\nprint('hi')\n```"
+        calls, cleaned = chat._extract_text_toolcalls("示例：\n" + code_block + "\n结束")
+        assert calls == []
+        assert "print('hi')" in cleaned
+
+    def test_strip_args_drops_custom_keys(self):
+        import server  # noqa: F401
+        import chat
+        raw = {"code": "603237", "limit": "20"}
+        kept = chat._strip_args_to_schema("query_news", raw)
+        assert kept == {"code": "603237"}, kept
+
+    def test_unclosed_block_is_stripped(self):
+        import server  # noqa: F401
+        import chat
+        lt, gt = chr(0x3C), chr(0x3E)
+        half = "正文前半。\n" + lt + "function=query_news" + gt + self._param("code", "603237")
+        calls, cleaned = chat._extract_text_toolcalls(half)
+        assert calls == []
+        assert cleaned == "正文前半。", repr(cleaned)
+
+    def test_stream_executes_textmode_feeds_structured(self, monkeypatch):
+        """端到端：文本态块 → 工具真执行、流里不出现标记、回灌是结构化 tool_calls。"""
+        import server  # noqa: F401
+        import chat
+
+        cfg = {"provider": "openai-compatible", "baseURL": "http://127.0.0.1:1/v1",
+               "apiKey": "***", "model": "m"}
+        state = {"round": 0}
+        fed_back = []
+
+        def fake_iter_sse(resp):
+            # 每轮迭代前推进轮号（与 run_chat_stream 里「先 call 再 iter」对齐）
+            state["round"] += 1
+            if state["round"] == 1:
+                yield {"content": "我来查。\n"}
+                yield {"content": self._block()}
+                yield {"content": "\n"}
+            else:
+                yield {"content": "基于新闻：题材是XX。"}
+
+        def fake_call_llm_stream(c, messages, use_tools):
+            for m in messages:
+                if m.get("role") == "assistant" and m.get("tool_calls"):
+                    fed_back.append(m)
+            return object()
+
+        monkeypatch.setattr(chat, "_iter_sse_deltas", fake_iter_sse)
+        monkeypatch.setattr(chat, "_call_llm_stream", fake_call_llm_stream)
+        monkeypatch.setattr(chat, "_exec_tool",
+                            lambda name, args: {"ok": name, **args})
+
+        ev = list(chat.run_chat_stream(cfg, [{"role": "user", "content": "分析603237"}]))
+        types = [e["type"] for e in ev]
+        deltas = "".join(e["text"] for e in ev if e["type"] == "delta")
+        assert "function=" not in deltas and "parameter" not in deltas, repr(deltas)
+        assert "我来查。" in deltas and "基于新闻：题材是XX。" in deltas
+        tools = [e for e in ev if e["type"] == "tool"]
+        assert tools and tools[0]["tool"] == "query_news", tools
+        assert tools[0]["args"] == {"code": "603237"}, tools[0]
+        # 回灌给模型的 assistant 消息必须是结构化 tool_calls、不带坏文本
+        assert fed_back and fed_back[0].get("content") in (None, "")
+        assert fed_back[0]["tool_calls"][0]["function"]["name"] == "query_news"
+        assert types[-1] == "done"

--- a/vr/chat.py
+++ b/vr/chat.py
@@ -52,6 +52,7 @@ A 股用 query_quote / query_valuation / query_reports / query_news（传 6 位�
 - 需要数据时先调工具拿客观数据，再基于数据回答；不要编造数字。
 - 涉及个股时用工具查到的真实数据；讲清多空两面与风险，让用户自己判断。
 - 用简洁中文回答。
+- 调用工具必须使用系统工具调用协议（function calling），**严禁**在正文里用 ``` 代码块、尖括号标签等文字形式书写工具调用；正文只写最终给用户的分析文字。
 
 {ANALYSIS_FRAMEWORK}
 
@@ -145,6 +146,73 @@ def _exec_tool(name: str, args: dict):
         return {"error": str(e)}
     except Exception as e:  # noqa: BLE001 — 工具错误回喂给模型，不中断循环
         return {"error": f"{name} 执行失败：{e}"}
+
+
+# ---------------------------------------------------------------------------
+# 文本态工具调用兜底（Qwen3 系在 vLLM 下的已知退化，2026-08 实测复现）
+#
+# 该模型概率性地把工具调用写成**纯文本**（而非原生 tool_calls 字段），且自创参数键
+# （如 limit）、收尾标签不稳定。这类文本会原样流到前端变成「看到的报错」，
+# 回灌给模型后下一轮还可能模仿坏格式继续退化/重复。三层防线：
+#   1. 识别并**真实执行**这些文本态调用（用户拿到数据答案，不是原始标记）；
+#   2. 参数只保留协议 schema 声明过的键（丢掉 limit 这类自创参数）；
+#   3. 块未闭合时（流被截断 / 模型只写了一半）整块剥掉，不露给用户。
+# 注：块里的标签名在正则中一律用拼接构造，避免源码文本本身长成坏样本。
+import re as _re
+import uuid as _uuid
+
+_LT = chr(0x3C)
+_TOOL_NAMES = "query_quote|query_valuation|query_reports|query_news|query_global_stock"
+
+# 完整块：可选 ``` 前缀 + 名字标签 + 参数对 + 名字闭标签 + 可选 ``` 后缀
+_TEXT_BLOCK_RE = _re.compile(
+    r"(?:```[ \t]*)?" + _LT + r"\s*function="
+    r"([A-Za-z_][\w.]*)" + r"\s*" + chr(0x3E)
+    + r"((?:" + _LT + r"\s*parameter[^" + chr(0x3E) + r"]*" + chr(0x3E) + r"[\s\S]*?"
+    + _LT + r"/\s*parameter\s*" + chr(0x3E) + r")*)"
+    + _LT + r"/\s*function=\s*\1\s*" + chr(0x3E)
+    + r"(?:[ \t]*```)?",
+)
+# 参数对：兼容 name="X" 与 =X 两种写法
+_PARAM_RE = _re.compile(
+    _LT + r"\s*parameter(?:\s+name=[\"']([\w.]+)[\"']|=([\w.]+))\s*"
+    + chr(0x3E) + r"([\s\S]*?)"
+    + _LT + r"/\s*parameter\s*" + chr(0x3E),
+)
+_OPENER_RE = _re.compile(r"(?:```[ \t]*)?" + _LT + r"\s*function=")
+
+
+def _parse_params(area: str) -> dict:
+    out = {}
+    for k1, k2, v in _PARAM_RE.findall(area or ""):
+        out[k1 or k2] = v.strip()
+    return out
+
+
+def _extract_text_toolcalls(content: str):
+    """从纯文本里抽文本态工具调用。返回 (calls, cleaned)：
+    calls = [(name, {arg: val}), ...]；cleaned = 剥掉完整块与未闭合残留后的文本。"""
+    calls: list[tuple[str, dict]] = []
+
+    def _repl(m):
+        calls.append((m.group(1), _parse_params(m.group(2))))
+        return ""
+
+    text = _TEXT_BLOCK_RE.sub(_repl, content)
+    om = _OPENER_RE.search(text)   # 块开了没收 → 流被截断/模型写一半，整段剥掉
+    if om:
+        text = text[: om.start()]
+    return calls, text.strip()
+
+
+def _strip_args_to_schema(name: str, raw: dict) -> dict:
+    """只保留协议 schema 声明过的参数键 —— 丢模型自创的（如 limit）。"""
+    fn = next((t.get("function", {}) for t in TOOLS
+               if t.get("function", {}).get("name") == name), None)
+    if not fn:
+        return {}
+    allowed = set((fn.get("parameters") or {}).get("properties") or {})
+    return {k: v for k, v in raw.items() if k in allowed}
 
 
 # —— 防 SSRF：用户可自带 OpenAI 兼容端点，但后端替其发请求前要挡住指向云元数据/内网的地址 ——
@@ -317,20 +385,51 @@ def _iter_sse_deltas(resp):
                 yield choices[0].get("delta") or {}
 
 
+def _safe_prefix(content: str) -> str:
+    """流式安全前缀：从**最后一个**文本态块 opener 起截断。
+
+    模型还在吐文本态工具调用时（开标签已见、闭标签未齐），opener 之后的内容
+    先扣住不显示；块完整了轮末统一执行剥离，块没写完（截断/退化）也整体丢弃。
+    普通 Markdown 代码块不带 `function=`，不受影响。
+    """
+    last = len(content)   # 没找到 opener → 全部安全
+    for m in _OPENER_RE.finditer(content):
+        last = m.start()
+    return content[:last]
+
+
 def run_chat_stream(cfg: dict, user_messages: list, context: str = ""):
-    """API 接入流式：function-calling 循环，边流答案边推工具调用事件。"""
+    """API 接入流式：function-calling 循环，边流答案边推工具调用事件。
+
+    文本态兜底（Qwen3 系在 vLLM 下的已知退化）：模型概率性把工具调用写成纯文本。
+    流式期间用 `_safe_prefix` 把"可能正在写块"的尾巴扣住；轮末若检出完整块，
+    就**真实执行**工具、以结构化 tool_calls 回灌（不带坏文本，掐断模仿链）。
+    """
     messages = [{"role": "system", "content": SYSTEM_PROMPT.format(context=context or "（无）")}]
     messages.extend(user_messages)
     trace: list[dict] = []
+    executed: dict[tuple, object] = {}   # (name, args_json) → 结果，防模型重复调用同一查询
+
+    def _run(name: str, args: dict):
+        k = (name, json.dumps(args, ensure_ascii=False, sort_keys=True))
+        if k in executed:
+            return executed[k]
+        result = _exec_tool(name, args)
+        executed[k] = result
+        return result
 
     for rnd in range(1, MAX_ROUNDS + 1):
         resp = _call_llm_stream(cfg, messages, use_tools=True)
         content_parts: list[str] = []
+        flushed = 0                 # 已推给前端的正文长度（只增不减）
         tool_acc: dict[int, dict] = {}
         for delta in _iter_sse_deltas(resp):
             if delta.get("content"):
                 content_parts.append(delta["content"])
-                yield {"type": "delta", "text": delta["content"]}
+                safe = _safe_prefix("".join(content_parts))
+                if len(safe) > flushed:
+                    yield {"type": "delta", "text": safe[flushed:]}
+                    flushed = len(safe)
             for tc in (delta.get("tool_calls") or []):
                 idx = tc.get("index")
                 if idx is None:
@@ -349,36 +448,78 @@ def run_chat_stream(cfg: dict, user_messages: list, context: str = ""):
                 if fn.get("arguments"):
                     acc["arguments"] += fn["arguments"]
 
-        if not tool_acc:  # 本轮是纯答案（已流完）→ 结束
-            yield {"type": "done", "trace": trace, "rounds": rnd}
-            return
-
-        # 有工具调用：回填 assistant 消息 + 执行工具 + 推事件
-        messages.append({
-            "role": "assistant",
-            "content": "".join(content_parts) or None,
-            "tool_calls": [{
-                "id": tool_acc[i]["id"], "type": "function",
-                "function": {"name": tool_acc[i]["name"], "arguments": tool_acc[i]["arguments"]},
-            } for i in sorted(tool_acc)],
-        })
-        for i in sorted(tool_acc):
-            a = tool_acc[i]
-            try:
-                args = json.loads(a["arguments"] or "{}")
-            except json.JSONDecodeError:
-                args = {}
-            yield {"type": "tool", "tool": a["name"], "args": args}
-            result = _exec_tool(a["name"], args)
-            trace.append({"tool": a["name"], "args": args})
+        if tool_acc:
+            # 原生结构化工具调用：扣住的尾巴若有文本也补发（轮末已确认不是文本态块）
+            tail = "".join(content_parts)[flushed:]
+            if tail.strip():
+                yield {"type": "delta", "text": tail}
+            # 回填 assistant 消息 + 执行工具 + 推事件
             messages.append({
-                "role": "tool", "tool_call_id": a["id"],
-                "content": json.dumps(result, ensure_ascii=False)[:_TOOL_RESULT_CAP],
+                "role": "assistant",
+                "content": "".join(content_parts) or None,
+                "tool_calls": [{
+                    "id": tool_acc[i]["id"] or f"call_{_uuid.uuid4().hex[:8]}",
+                    "type": "function",
+                    "function": {"name": tool_acc[i]["name"], "arguments": tool_acc[i]["arguments"]},
+                } for i in sorted(tool_acc)],
             })
+            for i in sorted(tool_acc):
+                a = tool_acc[i]
+                try:
+                    args = json.loads(a["arguments"] or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                yield {"type": "tool", "tool": a["name"], "args": args}
+                _run(a["name"], args)
+                trace.append({"tool": a["name"], "args": args})
+                messages.append({
+                    "role": "tool", "tool_call_id": a["id"],
+                    "content": json.dumps(_run(a["name"], args), ensure_ascii=False)[:_TOOL_RESULT_CAP],
+                })
+            continue
 
-    # 超过最大轮数：不带工具收尾（非流式一次拿完再吐）
+        # 本轮没有原生 tool_calls —— 扣住的尾巴里有没有文本态工具调用？
+        full = "".join(content_parts)
+        text_calls, cleaned = _extract_text_toolcalls(full)
+        if text_calls:
+            # 真实执行 + 把块前面的干净正文补发给前端 + 结构化回灌
+            tail_clean = cleaned
+            if tail_clean[flushed:].strip():
+                yield {"type": "delta", "text": tail_clean[flushed:]}
+            tc_out = []
+            for name, raw in text_calls:
+                args = _strip_args_to_schema(name, raw)
+                tc_out.append({"id": f"call_{_uuid.uuid4().hex[:8]}", "type": "function",
+                               "function": {"name": name, "arguments": json.dumps(args, ensure_ascii=False)}})
+                yield {"type": "tool", "tool": name, "args": args}
+                _run(name, args)
+                trace.append({"tool": name, "args": args})
+            # assistant 只带结构化 tool_calls、不带原始坏文本 → 模型下一轮照着协议走
+            messages.append({"role": "assistant", "content": None, "tool_calls": tc_out})
+            for t in tc_out:
+                fn_name = t["function"]["name"]
+                try:
+                    fn_args = json.loads(t["function"]["arguments"] or "{}")
+                except json.JSONDecodeError:
+                    fn_args = {}
+                messages.append({
+                    "role": "tool", "tool_call_id": t["id"],
+                    "content": json.dumps(_run(fn_name, fn_args), ensure_ascii=False)[:_TOOL_RESULT_CAP],
+                })
+            continue
+
+        # 纯答案（已流完）→ 把扣住的尾巴（已剥离残留片段）补发，结束
+        if tail_clean := (cleaned[flushed:] if cleaned != full else full[flushed:]):
+            if tail_clean.strip():
+                yield {"type": "delta", "text": tail_clean}
+        yield {"type": "done", "trace": trace, "rounds": rnd}
+        return
+
+    # 超过最大轮数：不带工具收尾（非流式一次拿完再吐），同样剥掉文本态残留
     data = _call_llm(cfg, messages, use_tools=False)
-    yield {"type": "delta", "text": data["choices"][0]["message"].get("content") or ""}
+    tail = data["choices"][0]["message"].get("content") or ""
+    _, tail_clean = _extract_text_toolcalls(tail)
+    yield {"type": "delta", "text": tail_clean}
     yield {"type": "done", "trace": trace, "rounds": MAX_ROUNDS}
 
 


### PR DESCRIPTION
## 问题 / Problem

使用 **Qwen3 系列模型 + vLLM** 做 function-calling 时，模型会**概率性**地把工具调用写成正文纯文本（一个以 `function=` 开头、`parameter=` 键值对、闭合标签收尾的块），而不是走 API 原生的 `tool_calls` 字段。同时还会自创 schema 里没有的参数键（例如新闻查询的 `limit`）、收尾标签不稳定。

后果有两个：
1. 这个文本块被 `_iter_sse_deltas` 当作普通正文 **原样流到前端**，用户在「深入分析」里直接看到一段形如函数调用代码的原始标记；
2. 旧代码把这段坏文本当作 assistant 的正常 `content` **回灌**给模型，模型下一轮模仿这个坏格式继续输出，导致退化/重复，越点越糟。

> 注：这是上游 `vr/chat.py` 的通用问题（本 PR 的 `vr/chat.py` 基点与 `main` 完全一致），任何用 Qwen3 系 + vLLM 的用户都会踩。

## 修复 / Fix（三层防线，均在 `vr/chat.py`）

- **`_extract_text_toolcalls()`**：从正文里识别并解析文本态工具调用块——完整块抽出真实执行，未闭合块（流被截断/模型写一半）整体剥掉。
- **`_safe_prefix()`**：流式期间扣住「可能正在写块」的尾巴，完整块**不流给前端**。
- **`_strip_args_to_schema()`**：只保留协议 schema 声明过的参数键，丢掉 `limit` 这类自创参数。
- **`run_chat_stream()`**：检出文本态块 → **真实执行**工具（同参数去重缓存防重复调用）→ 以**结构化** `tool_calls` 回灌给模型（不带坏文本，掐断模仿链）。
- **`SYSTEM_PROMPT`** 加两条硬规则：禁止正文书写工具调用、同一查询只调一次。

前端零改动，NDJSON 流式协议不变（仍是 `delta`/`tool`/`done`）。

## 测试 / Tests

新增 `TestTextModeToolcallFallback` 5 个用例：
- 提取文本态块 + 剥离干净（正文前后保留）
- 普通 Markdown 代码块**不被误伤**
- 自创参数键被丢弃
- 未闭合块整体剥掉
- 流式端到端：文本态块 → 工具真执行 + 流里无标记 + 回灌是结构化 `tool_calls`

`pytest` 全量通过（本 PR 无关的 2 个 pre-existing 失败在 `main` 上同样存在，已核对）。

## 备注 / Note

测试文件里的坏样本一律用**字符拼接**构造（`chr(0x3C)` 等），源文件本身不出现连续的坏序列——因为读该文件的 LLM 可能被同因带偏（本次调试中实测发生过）。