### PR TITLE
fix(server): 缓存写入前建目录，修 deepdive/backtest 首次运行 FileNotFoundError

### DIFF
--- a/server.py
+++ b/server.py
@@ -312,6 +312,7 @@ def _job_stuck(job: dict, limit: int) -> bool:
 
 
 def _atomic_write(path: str, payload: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)  # 缓存目录首次写时可能尚不存在
     tmp = f"{path}.{uuid.uuid4().hex}.tmp"
     with open(tmp, "w", encoding="utf-8") as fh:
         json.dump(payload, fh, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## 问题

v0.2.0 新增「个股深挖」后，**首次点击报错**：

```
FileNotFoundError: [Errno 2] No such file or directory:
'<user>/.duanxian-agents/deepdive/latest.json.<hash>.tmp'
```

「短线策略回测」（`/backtest`）首次请求同样中招：缓存写
`~/.duanxian-agents/backtest/last55.json.<hash>.tmp` 失败，日志刷
「回测缓存写入失败（每次请求都会重算）」，之后每次请求都重算 ~7s。

## 根因

`server.py` 的 `_atomic_write` 是**所有 JSON 缓存的收口**（deepdive /
backtest / weekly / reviews 都走它），但写 tmp 文件前不建目录：

```python
def _atomic_write(path, payload):
    tmp = f"{path}.{uuid}.tmp"      # 目录不存在 → FileNotFoundError
    with open(tmp, "w") ...
```

模块顶部只 `makedirs` 了 `_REVIEW_DIR` / `_WK_DIR` 两个老目录；
v0.2.0 新增的 `_DD_DIR` 没有、backtest 的 `RESULT_DIR` 也从来没人建。
「启动时逐个建目录」这个模式每加一个目录就要记一行，漏一行 = 一个
首次运行 500。

## 修复

在**收口点**统一建目录，一行覆盖现有与未来所有缓存目录：

```python
def _atomic_write(path, payload):
    os.makedirs(os.path.dirname(path), exist_ok=True)
    tmp = f"{path}.{uuid}.tmp"
    ...
```

## 验证

- 删除 `~/.duanxian-agents/deepdive` 与 `backtest` 目录后重启：两个目录自动重建
- `/api/deepdive/latest` 由 500 → **200**
- `/api/backtest?days=55` 首次 5.5s 计算 + 落盘 `last55.json`，二次 **0.45s** 命中缓存；日志无「回测缓存写入失败」
- `pytest -k "deepdive or backtest or journal"` **39 passed**

## 影响面

仅 `server.py` 的 `_atomic_write` 加 1 行 `os.makedirs(..., exist_ok=True)`，无逻辑改动，幂等。
