### PR TITLE
feat: 支持 CC Switch 本机 Responses 路由

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Windows 也在本机浏览器中使用；需要安装 Python（含 `py` 启动�
 | WorkBuddy / CodeBuddy | 使用本机 CLI 登录；本次仅实测 macOS WorkBuddy 内置 CodeBuddy CLI 2.137.1 的连接、受控工具、普通对话与单日完整复盘流程 |
 | OpenAI API | 使用用户自己的配置；不以订阅测试代替 API 实测，尚未完成全部兼容验收 |
 | DeepSeek / MiMo | 提供模型与地址预设，支持自行修改；使用自己的密钥测试成功后保存 |
+| CC Switch 本机路由 | 仅精确放行 `http://127.0.0.1:15721/v1`；需本机路由支持流式 Responses 与工具调用，模型由用户按实际路由填写，密钥通常填 `PROXY_MANAGED` |
 | 智谱 GLM / Kimi / 通义千问 | 提供阿里云百炼预设，需要填写工作空间地址和百炼密钥；须以实际连接测试为准 |
 | 硅基流动 / MiniMax / OpenRouter / Groq / Together / 自定义 | 提供可编辑的地址与模型配置；预设不代表兼容性已验证，端点必须支持 Responses API 与工具调用 |
 

--- a/frontend/src/components/AgentAccess.tsx
+++ b/frontend/src/components/AgentAccess.tsx
@@ -94,7 +94,7 @@ export function AgentAccess({initialProvider,onSaved,onBusyChange}:{initialProvi
  }
  function choose(value:string){
   const next=draftFor(value);
-  setCatalog(null);setSubscription(null);setProvider(next.provider);setModel(next.model);setBaseURL(next.baseURL);setApiKey('');setError('');setNotice('');
+  setCatalog(null);setSubscription(null);setProvider(next.provider);setModel(next.model);setBaseURL(next.baseURL);setApiKey(next.apiKey);setError('');setNotice('');
  }
  return <section aria-label="复盘与追问 AI 接入" className="space-y-4 rounded-xl border border-border bg-card p-4 sm:p-6">
   <div><h2 className="font-semibold">接入 AI</h2><p className="mt-1 text-sm leading-6 text-muted-foreground">选择订阅或模型 API，首页聊天、复盘和研究共用这份连接。</p></div>

--- a/frontend/src/lib/ai-access.ts
+++ b/frontend/src/lib/ai-access.ts
@@ -3,6 +3,7 @@ type Connection = { provider: string; model: string; baseURL: string; apiKey: st
 export type AccessDraft = Connection;
 const bailian = 'https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1';
 const hosted = '通过阿里云百炼接入，请使用百炼工作空间的地址和密钥。';
+const ccSwitch = 'http://127.0.0.1:15721/v1';
 export const SUBSCRIPTION_PROVIDERS = [
   { id: 'codex-private', name: 'Codex 订阅', detail: '使用 ChatGPT 账户登录产品专用空间' },
   { id: 'claude', name: 'Claude 订阅', detail: '使用本机 Claude Code 登录' },
@@ -14,6 +15,8 @@ const preset = (id: string, name: string, baseURL: string, models: string[], det
 export const API_PROVIDERS = [
   preset('deepseek', 'DeepSeek', 'https://api.deepseek.com', ['deepseek-v4-flash', 'deepseek-v4-pro']),
   preset('mimo', 'MiMo', 'https://token-plan-cn.xiaomimimo.com/v1', ['mimo-v2.5', 'mimo-v2.5-pro']),
+  preset('cc-switch', 'CC Switch 本机路由', ccSwitch, [],
+    'CC Switch 需在本机开启 Responses 路由；API 密钥通常填 PROXY_MANAGED，模型可按路由自行填写。'),
   preset('glm', '智谱 GLM', bailian, ['glm-5.2'], hosted),
   preset('kimi', 'Kimi', bailian, ['kimi-k2.7-code'], hosted),
   preset('qwen', '通义千问', bailian, ['qwen3.8-max'], hosted),
@@ -46,7 +49,8 @@ export function providerFor(connection: Connection): string {
 export function draftFor(provider: string, saved?: Connection | null): AccessDraft {
   if (saved && providerFor(saved) === provider) return { provider, model: saved.model, baseURL: saved.baseURL, apiKey: isSubscription(provider) ? '' : saved.apiKey };
   const entry = API_PROVIDERS.find(p => p.id === provider);
-  return { provider, model: entry?.models[0]?.id ?? (['claude', 'codebuddy'].includes(provider) ? 'default' : ''), baseURL: entry?.baseURL ?? '', apiKey: '' };
+  return { provider, model: entry?.models[0]?.id ?? (['claude', 'codebuddy'].includes(provider) ? 'default' : ''),
+           baseURL: entry?.baseURL ?? '', apiKey: entry?.id === 'cc-switch' ? 'PROXY_MANAGED' : '' };
 }
 export function connectionFor(draft: AccessDraft): Connection {
   if (isSubscription(draft.provider)) return { provider: draft.provider, model: draft.model.trim(), baseURL: '', apiKey: '' };
@@ -65,8 +69,11 @@ export function draftError(draft: AccessDraft): string {
   if (/[{}<>]|%7b|%7d|%3c|%3e/i.test(base)) return '请将地址中的 WorkspaceId 等占位符替换为实际工作空间信息';
   try {
     const url = new URL(base);
-    if (!/^https:\/\//.test(base) || url.protocol !== 'https:' || url.username || url.password || url.search || url.hash || url.port || /\s|\\/.test(base)) throw new Error();
-  } catch { return '请填写 HTTPS API 基础地址，不含账号、查询参数或非标准端口'; }
+    const localResponsesRoute = base === ccSwitch;
+    const secureResponsesRoute = /^https:\/\//.test(base) && url.protocol === 'https:' && !url.port;
+    if (url.username || url.password || url.search || url.hash || /\s|\\/.test(base) ||
+        (!localResponsesRoute && !secureResponsesRoute)) throw new Error();
+  } catch { return '请填写 HTTPS API 基础地址，或本机 CC Switch Responses 路由'; }
   const key = draft.apiKey.trim();
   if (!key || key.length > 1024 || /\s/.test(key)) return '请填写该服务商的有效 API 密钥';
   return '';

--- a/review_agent/runtime.py
+++ b/review_agent/runtime.py
@@ -84,6 +84,9 @@ accepted=true 后立即结束本轮，最终聊天文字只说“分析完成”
 只解释证据直接支持的变化，计数升降不能推出盘中时点、约束松紧、资金动机或因果机制；缺少对应资料时明确不作判断。"""
 
 
+CC_SWITCH_RESPONSES_URL = "http://127.0.0.1:15721/v1"
+
+
 def connection(llm: dict) -> tuple[dict, str]:
     """Return public identity separately from the ephemeral credential."""
     if not isinstance(llm, dict):
@@ -102,13 +105,15 @@ def connection(llm: dict) -> tuple[dict, str]:
     if re.search(r"[{}<>]|%7b|%7d|%3c|%3e", base, re.IGNORECASE):
         raise EvidenceError("请将 API 地址中的 WorkspaceId 等占位符替换为实际工作空间信息")
     try:
+        base = base.rstrip("/")
         url = urlparse(base)
-        valid = url.scheme == "https" and url.hostname and not url.username and not url.password and not url.query and not url.fragment and url.port in (None, 443)
+        local_responses = base == CC_SWITCH_RESPONSES_URL
+        valid = url.hostname and not url.username and not url.password and not url.query and not url.fragment and (
+            local_responses or (url.scheme == "https" and url.port in (None, 443)))
     except ValueError:
         valid = False
     if not valid or (provider != "api-compatible" and base.rstrip("/") not in allowed):
-        raise EvidenceError("请填写 HTTPS Responses API 地址；不支持带凭据、查询参数或非标准端口的地址")
-    base = base.rstrip("/")
+        raise EvidenceError("请填写 HTTPS Responses API 地址，或本机 CC Switch Responses 路由；不支持带凭据、查询参数或其它非标准端口地址")
     key = llm.get("apiKey", "")
     if not isinstance(key, str) or not key.strip() or len(key) > 1024 or any(c.isspace() for c in key):
         raise EvidenceError("API 密钥无效，请检查接入 AI 设置")

--- a/tests/test_ai_access_frontend.py
+++ b/tests/test_ai_access_frontend.py
@@ -1,0 +1,41 @@
+"""前端 AI 接入配置的行为契约。"""
+
+import subprocess
+from pathlib import Path
+
+
+def test_cc_switch_route_has_editable_model_preset():
+    script = """
+    const m = await import('./frontend/src/lib/ai-access.ts');
+    const entry = m.API_PROVIDERS.find(p => p.id === 'cc-switch');
+    if (!entry || entry.name !== 'CC Switch 本机路由' || entry.baseURL !== 'http://127.0.0.1:15721/v1') process.exit(2);
+    if (entry.models.length !== 0 || !entry.detail.includes('PROXY_MANAGED')) process.exit(3);
+    if (m.draftFor('cc-switch').apiKey !== 'PROXY_MANAGED') process.exit(4);
+    """
+    result = subprocess.run(['node', '--input-type=module', '-e', script], cwd=Path(__file__).parents[1])
+    assert result.returncode == 0
+
+
+def test_frontend_only_allows_exact_cc_switch_http_route():
+    script = """
+    const m = await import('./frontend/src/lib/ai-access.ts');
+    const valid = [
+      {provider: 'api-compatible', model: 'glm-5.3', baseURL: 'http://127.0.0.1:15721/v1', apiKey: 'PROXY_MANAGED'},
+      {provider: 'api-compatible', model: 'm', baseURL: 'https://example.com/v1', apiKey: 'k'},
+    ];
+    const invalid = [
+      {provider: 'api-compatible', model: 'glm-5.3', baseURL: 'http://127.0.0.1:15722/v1', apiKey: 'PROXY_MANAGED'},
+      {provider: 'api-compatible', model: 'm', baseURL: 'http://localhost:15721/v1', apiKey: 'k'},
+      {provider: 'api-compatible', model: 'm', baseURL: 'https://user@example.com/v1', apiKey: 'k'},
+      {provider: 'api-compatible', model: 'm', baseURL: 'https://example.com/v1?x=1', apiKey: 'k'},
+    ];
+    if (valid.some(x => m.draftError(x) !== '')) process.exit(2);
+    if (invalid.some(x => m.draftError(x) === '')) process.exit(3);
+    """
+    result = subprocess.run(['node', '--input-type=module', '-e', script], cwd=Path(__file__).parents[1])
+    assert result.returncode == 0
+
+
+def test_switching_provider_keeps_preset_placeholder_key():
+    src = Path('frontend/src/components/AgentAccess.tsx').read_text(encoding='utf-8')
+    assert 'setApiKey(next.apiKey);' in src

--- a/tests/test_api_presets.py
+++ b/tests/test_api_presets.py
@@ -16,6 +16,32 @@ def test_api_preset_reaches_responses_engine_unchanged(tmp_path, url):
     assert source['model'] == 'custom/model'
     assert key == 'TEST_ONLY_KEY' and key not in repr(config)
 
+
+def test_cc_switch_local_route_reaches_responses_engine(tmp_path):
+    source, key = connection({
+        'provider': 'api-compatible', 'baseURL': 'http://127.0.0.1:15721/v1/',
+        'model': 'glm-5.3-flash', 'apiKey': 'PROXY_MANAGED',
+    })
+    config = config_for(tmp_path, source)
+    assert source == {'provider': 'api-compatible', 'model': 'glm-5.3-flash',
+                      'baseURL': 'http://127.0.0.1:15721/v1'}
+    assert config['model_providers.astock_api']['wire_api'] == 'responses'
+    assert key == 'PROXY_MANAGED'
+
+
+@pytest.mark.parametrize('url', [
+    'http://127.0.0.1:15721',
+    'http://127.0.0.1:15721/v2',
+    'http://127.0.0.1:15722/v1',
+    'http://localhost:15721/v1',
+    'http://192.168.1.8:15721/v1',
+])
+def test_other_local_http_routes_remain_rejected(url):
+    with pytest.raises(EvidenceError):
+        connection({'provider': 'api-compatible', 'baseURL': url,
+                    'model': 'glm-5.3', 'apiKey': 'PROXY_MANAGED'})
+
+
 @pytest.mark.parametrize('url', ['https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1', 'https://host/<workspace>/v1'])
 def test_unfilled_endpoint_placeholder_is_rejected(url):
     with pytest.raises(EvidenceError):


### PR DESCRIPTION
## Summary
- 新增「CC Switch 本机路由」API 预设，模型保持由用户填写，密钥默认填入 `PROXY_MANAGED`
- 前后端仅精确放行 `http://127.0.0.1:15721/v1`，继续拒绝其它 HTTP、局域网、带凭据或查询参数地址
- 保持 Codex provider 使用 `wire_api: "responses"`，并补充前端行为测试与后端地址边界测试
- 更新 README 中的接入说明

## Validation
- `.venv/bin/python -m pytest tests backtest/tests research_data/tests -q`
  - 1291 passed, 5 skipped, 1 existing deprecation warning
- `npm run build --prefix frontend`
- `sh scripts/doctor`
- 通过项目真实连接测试验证 CC Switch 路由：
  - `glm-5.3`
  - `glm-5.3-flash`
  - 均完成 Responses 流式调用与证据工具调用